### PR TITLE
修复问题

### DIFF
--- a/src/main/java/com/ztbsuper/dingding/JobListener.java
+++ b/src/main/java/com/ztbsuper/dingding/JobListener.java
@@ -30,10 +30,10 @@ public class JobListener extends RunListener<AbstractBuild> {
     @Override
     public void onCompleted(AbstractBuild r, @Nonnull TaskListener listener) {
         Result result = r.getResult();
-        if (null != result && result.equals(Result.FAILURE)) {
-            getService(r, listener).failed();
-        } else {
+        if (null != result && result.equals(Result.SUCCESS)) {
             getService(r, listener).success();
+        } else {
+            getService(r, listener).failed();
         }
     }
 


### PR DESCRIPTION
只有在build状态为success的时候才通知成功，其他的时候都为failed。因为存在中断等其他case，归类为失败更合适