### PR TITLE
add abort choice.

### DIFF
--- a/src/main/java/com/ztbsuper/dingding/DingdingNotifier.java
+++ b/src/main/java/com/ztbsuper/dingding/DingdingNotifier.java
@@ -28,6 +28,8 @@ public class DingdingNotifier extends Notifier {
     private boolean onSuccess;
 
     private boolean onFailed;
+    
+    private boolean onAbort;
 
     public String getJenkinsURL() {
         return jenkinsURL;
@@ -46,23 +48,28 @@ public class DingdingNotifier extends Notifier {
     public boolean isOnFailed() {
         return onFailed;
     }
+    
+    public boolean onAbort() {
+        return onAbort;
+    }
 
     public String getAccessToken() {
         return accessToken;
     }
 
     @DataBoundConstructor
-    public DingdingNotifier(String accessToken, boolean onStart, boolean onSuccess, boolean onFailed, String jenkinsURL) {
+    public DingdingNotifier(String accessToken, boolean onStart, boolean onSuccess, boolean onFailed, boolean onAbort, String jenkinsURL) {
         super();
         this.accessToken = accessToken;
         this.onStart = onStart;
         this.onSuccess = onSuccess;
         this.onFailed = onFailed;
+        this.onAbort = onAbort;
         this.jenkinsURL = jenkinsURL;
     }
 
     public DingdingService newDingdingService(AbstractBuild build, TaskListener listener) {
-        return new DingdingServiceImpl(jenkinsURL, accessToken, onStart, onSuccess, onFailed, listener, build);
+        return new DingdingServiceImpl(jenkinsURL, accessToken, onStart, onSuccess, onFailed, onAbort, listener, build);
     }
 
     @Override

--- a/src/main/java/com/ztbsuper/dingding/DingdingService.java
+++ b/src/main/java/com/ztbsuper/dingding/DingdingService.java
@@ -11,4 +11,6 @@ public interface DingdingService {
     void success();
 
     void failed();
+    
+    void abort();
 }

--- a/src/main/java/com/ztbsuper/dingding/DingdingServiceImpl.java
+++ b/src/main/java/com/ztbsuper/dingding/DingdingServiceImpl.java
@@ -31,6 +31,8 @@ public class DingdingServiceImpl implements DingdingService {
 
     private boolean onFailed;
 
+    private boolean onAbort;
+
     private TaskListener listener;
 
     private AbstractBuild build;
@@ -39,11 +41,12 @@ public class DingdingServiceImpl implements DingdingService {
 
     private String api;
 
-    public DingdingServiceImpl(String jenkinsURL, String token, boolean onStart, boolean onSuccess, boolean onFailed, TaskListener listener, AbstractBuild build) {
+    public DingdingServiceImpl(String jenkinsURL, String token, boolean onStart, boolean onSuccess, boolean onFailed, boolean onAbort, TaskListener listener, AbstractBuild build) {
         this.jenkinsURL = jenkinsURL;
         this.onStart = onStart;
         this.onSuccess = onSuccess;
         this.onFailed = onFailed;
+        this.onAbort =  onAbort;
         this.listener = listener;
         this.build = build;
         this.api = apiUrl + token;
@@ -94,6 +97,20 @@ public class DingdingServiceImpl implements DingdingService {
         String link = getBuildUrl();
         logger.info(link);
         if (onFailed) {
+            logger.info("send link msg from " + listener.toString());
+            sendLinkMessage(link, content, title, pic);
+        }
+    }
+
+    @Override
+    public void abort() {
+        String pic = "http://www.iconsdb.com/icons/preview/soylent-red/x-mark-3-xxl.png";
+        String title = String.format("%s%s构建中断", build.getProject().getDisplayName(), build.getDisplayName());
+        String content = String.format("项目[%s%s]构建中断, summary:%s, duration:%s", build.getProject().getDisplayName(), build.getDisplayName(), build.getBuildStatusSummary().message, build.getDurationString());
+
+        String link = getBuildUrl();
+        logger.info(link);
+        if (onAbort) {
             logger.info("send link msg from " + listener.toString());
             sendLinkMessage(link, content, title, pic);
         }

--- a/src/main/java/com/ztbsuper/dingding/JobListener.java
+++ b/src/main/java/com/ztbsuper/dingding/JobListener.java
@@ -32,8 +32,11 @@ public class JobListener extends RunListener<AbstractBuild> {
         Result result = r.getResult();
         if (null != result && result.equals(Result.SUCCESS)) {
             getService(r, listener).success();
-        } else {
+        } else if (null != result && result.equals(Result.FAILURE)) {
             getService(r, listener).failed();
+        // } else if (null != result && result.equals(Result.ABORTED)) {
+        } else {
+            getService(r, listener).abort();
         }
     }
 

--- a/src/main/resources/com/ztbsuper/dingding/DingdingNotifier/config.jelly
+++ b/src/main/resources/com/ztbsuper/dingding/DingdingNotifier/config.jelly
@@ -22,4 +22,7 @@
   <f:entry title="构建失败时通知">
       <f:checkbox name="onFailed" value="true" checked="${instance.isOnFailed()}"/>
   </f:entry>
+  <f:entry title="构建中断时通知">
+      <f:checkbox name="onAbort" value="true" checked="${instance.isOnAbort()}"/>
+  </f:entry>
 </j:jelly>


### PR DESCRIPTION
-  添加ABORT状态的判断(hudson接口)

我本地生成的hpi上传安装之后, 发现虽然多了中断的checkbox, 但是选中之后保存, 再次编辑JOB时候, 还是未选中状态, 但是实际是有生效的. 前辈麻烦指点一二, 是我的环境问题吗?

添加ABORT状态判断的原因在于, 我的每次构建, 在线程出错的情况下, JOB不会出错与成功, 因此要手动停止. 这种情况不希望在钉钉收到消息. 

望前辈调试之后能够合并代码, 谢谢!