### PR TITLE
”构建中断时通知“状态，在重新配置job后被清空

### DIFF
--- a/src/main/java/com/ztbsuper/dingding/DingdingNotifier.java
+++ b/src/main/java/com/ztbsuper/dingding/DingdingNotifier.java
@@ -48,8 +48,8 @@ public class DingdingNotifier extends Notifier {
     public boolean isOnFailed() {
         return onFailed;
     }
-    
-    public boolean onAbort() {
+
+    public boolean isOnAbort() {
         return onAbort;
     }
 


### PR DESCRIPTION
"构建中断时通知" 状态，在每次重新打开配置页面并保存后，被重置为unchecked