### PR TITLE
support unstable notify

### DIFF
--- a/src/main/java/com/ztbsuper/dingding/DingdingNotifier.java
+++ b/src/main/java/com/ztbsuper/dingding/DingdingNotifier.java
@@ -28,8 +28,10 @@ public class DingdingNotifier extends Notifier {
     private boolean onSuccess;
 
     private boolean onFailed;
-    
+
     private boolean onAbort;
+
+    private boolean onUnstable;
 
     public String getJenkinsURL() {
         return jenkinsURL;
@@ -48,9 +50,13 @@ public class DingdingNotifier extends Notifier {
     public boolean isOnFailed() {
         return onFailed;
     }
-    
+
     public boolean onAbort() {
         return onAbort;
+    }
+
+    public boolean isOnUnstable() {
+        return onUnstable;
     }
 
     public String getAccessToken() {
@@ -58,18 +64,19 @@ public class DingdingNotifier extends Notifier {
     }
 
     @DataBoundConstructor
-    public DingdingNotifier(String accessToken, boolean onStart, boolean onSuccess, boolean onFailed, boolean onAbort, String jenkinsURL) {
+    public DingdingNotifier(String accessToken, boolean onStart, boolean onSuccess, boolean onFailed, boolean onAbort, boolean onUnstable,String jenkinsURL) {
         super();
         this.accessToken = accessToken;
         this.onStart = onStart;
         this.onSuccess = onSuccess;
         this.onFailed = onFailed;
         this.onAbort = onAbort;
+        this.onUnstable=onUnstable;
         this.jenkinsURL = jenkinsURL;
     }
 
     public DingdingService newDingdingService(AbstractBuild build, TaskListener listener) {
-        return new DingdingServiceImpl(jenkinsURL, accessToken, onStart, onSuccess, onFailed, onAbort, listener, build);
+        return new DingdingServiceImpl(jenkinsURL, accessToken, onStart, onSuccess, onFailed, onAbort, onUnstable, listener, build);
     }
 
     @Override

--- a/src/main/java/com/ztbsuper/dingding/DingdingService.java
+++ b/src/main/java/com/ztbsuper/dingding/DingdingService.java
@@ -13,4 +13,6 @@ public interface DingdingService {
     void failed();
     
     void abort();
+
+    void unstable();
 }

--- a/src/main/java/com/ztbsuper/dingding/DingdingServiceImpl.java
+++ b/src/main/java/com/ztbsuper/dingding/DingdingServiceImpl.java
@@ -33,6 +33,8 @@ public class DingdingServiceImpl implements DingdingService {
 
     private boolean onAbort;
 
+    private boolean onUnstable;
+
     private TaskListener listener;
 
     private AbstractBuild build;
@@ -41,12 +43,13 @@ public class DingdingServiceImpl implements DingdingService {
 
     private String api;
 
-    public DingdingServiceImpl(String jenkinsURL, String token, boolean onStart, boolean onSuccess, boolean onFailed, boolean onAbort, TaskListener listener, AbstractBuild build) {
+    public DingdingServiceImpl(String jenkinsURL, String token, boolean onStart, boolean onSuccess, boolean onFailed, boolean onAbort, boolean onUnstable,TaskListener listener, AbstractBuild build) {
         this.jenkinsURL = jenkinsURL;
         this.onStart = onStart;
         this.onSuccess = onSuccess;
         this.onFailed = onFailed;
         this.onAbort =  onAbort;
+        this.onUnstable=onUnstable;
         this.listener = listener;
         this.build = build;
         this.api = apiUrl + token;
@@ -111,6 +114,20 @@ public class DingdingServiceImpl implements DingdingService {
         String link = getBuildUrl();
         logger.info(link);
         if (onAbort) {
+            logger.info("send link msg from " + listener.toString());
+            sendLinkMessage(link, content, title, pic);
+        }
+    }
+
+    @Override
+    public void unstable() {
+        String pic = "https://www.iconsdb.com/icons/preview/orange/warning-xxl.png";
+        String title = String.format("%s%s构建不稳定", build.getProject().getDisplayName(), build.getDisplayName());
+        String content = String.format("项目[%s%s]构建不稳定, summary:%s, duration:%s", build.getProject().getDisplayName(), build.getDisplayName(), build.getBuildStatusSummary().message, build.getDurationString());
+
+        String link = getBuildUrl();
+        logger.info(link);
+        if (onUnstable) {
             logger.info("send link msg from " + listener.toString());
             sendLinkMessage(link, content, title, pic);
         }

--- a/src/main/java/com/ztbsuper/dingding/JobListener.java
+++ b/src/main/java/com/ztbsuper/dingding/JobListener.java
@@ -34,8 +34,10 @@ public class JobListener extends RunListener<AbstractBuild> {
             getService(r, listener).success();
         } else if (null != result && result.equals(Result.FAILURE)) {
             getService(r, listener).failed();
-        // } else if (null != result && result.equals(Result.ABORTED)) {
-        } else {
+        } else if (null != result && result.equals(Result.UNSTABLE)) {
+            getService(r, listener).unstable();
+        }// } else if (null != result && result.equals(Result.ABORTED)) {
+        else {
             getService(r, listener).abort();
         }
     }

--- a/src/main/resources/com/ztbsuper/dingding/DingdingNotifier/config.jelly
+++ b/src/main/resources/com/ztbsuper/dingding/DingdingNotifier/config.jelly
@@ -22,6 +22,9 @@
   <f:entry title="构建失败时通知">
       <f:checkbox name="onFailed" value="true" checked="${instance.isOnFailed()}"/>
   </f:entry>
+  <f:entry title="构建不稳定时通知">
+        <f:checkbox name="onUnstable" value="true" checked="${instance.isOnUnstable()}"/>
+    </f:entry>
   <f:entry title="构建中断时通知">
       <f:checkbox name="onAbort" value="true" checked="${instance.isOnAbort()}"/>
   </f:entry>


### PR DESCRIPTION
变更点：
1、增加Jenkins build状态为UNSTABLE时，可触发通知。
原因：
test case部分失败时，Jenkins build状态是UNSTABLE。之前无法收到UNSTABLE状态的通知，现加入。