### PR TITLE
upgrade fastjson to 1.2.58

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.12</version>
+            <version>1.2.58</version>
         </dependency>
         <dependency>
             <groupId>com.github.chnyangjie</groupId>


### PR DESCRIPTION
旧版本的fastjson会报安全漏洞，必须升级到更高版本。